### PR TITLE
Make sure the library plays well with webpack

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -54,7 +54,6 @@
  * characters will pass the minimum length check.  In other words, this
  * default assumes that no word is shorter than 3 characters.
  */
-({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports);}}).
 define(["exports"], function(exports){
 
 	exports.dictionary = [

--- a/src/passwdqc_check.js
+++ b/src/passwdqc_check.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2000-2002,2010,2013 by Solar Designer.  See LICENSE.
  * Copyright (c) 2014 Parallels, Inc.
  */
-({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./dictionary"));}}).
 define(["exports", "./dictionary"], function(exports, dict){
 	var dictionary = dict.dictionary;
 


### PR DESCRIPTION
Right now this library is not usable with webpack. It complains with 
```
amd-define.js:2 Uncaught Error: define cannot be used indirect
    at Object.push../node_modules/webpack/buildin/amd-define.js.module.exports [as define] (amd-define.js:2)
    at Object../node_modules/passwdqc/src/dictionary.js (dictionary.js:58)
    at __webpack_require__ (bootstrap:78)
    at Object../node_modules/passwdqc/src/passwdqc_check.js (passwdqc_check.js:6)
    at __webpack_require__ (bootstrap:78)
    at Module../src/app/app.component.ts (main.js:123)
    at __webpack_require__ (bootstrap:78)
    at Module../src/app/app.module.ts (app.component.ts:9)
    at __webpack_require__ (bootstrap:78)
    at Module../src/main.ts (main.ts:1)
```
